### PR TITLE
Fix missing paging on models `#all` methods

### DIFF
--- a/lib/fog/compute/google/models/addresses.rb
+++ b/lib/fog/compute/google/models/addresses.rb
@@ -11,16 +11,25 @@ module Fog
             :order_by => order_by,
             :page_token => page_token
           }
-
-          if region
-            data = service.list_addresses(region, **opts).items || []
-          else
-            data = []
-            service.list_aggregated_addresses(**opts).items.each_value do |scoped_list|
-              data.concat(scoped_list.addresses) if scoped_list && scoped_list.addresses
+          items = []
+          next_page_token = nil
+          loop do
+            if region
+              data = service.list_addresses(region, **opts)
+              next_items = data.items || []
+              items.concat(next_items)
+              next_page_token = data.next_page_token
+            else
+              data = service.list_aggregated_addresses(**opts)
+              data.items.each_value do |scoped_list|
+                items.concat(scoped_list.addresses) if scoped_list && scoped_list.addresses
+              end
+              next_page_token = data.next_page_token
             end
+            break if next_page_token.nil? || next_page_token.empty?
+            opts[:page_token] = next_page_token
           end
-          load(data.map(&:to_h))
+          load(items.map(&:to_h))
         end
 
         def get(identity, region = nil)

--- a/lib/fog/compute/google/models/firewalls.rb
+++ b/lib/fog/compute/google/models/firewalls.rb
@@ -5,8 +5,17 @@ module Fog
         model Fog::Compute::Google::Firewall
 
         def all(opts = {})
-          data = service.list_firewalls(**opts).to_h[:items]
-          load(data || [])
+          items = []
+          next_page_token = nil
+          loop do
+            data = service.list_firewalls(**opts)
+            next_items = data.to_h[:items] || []
+            items.concat(next_items)
+            next_page_token = data.next_page_token
+            break if next_page_token.nil? || next_page_token.empty?
+            opts[:page_token] = next_page_token
+          end
+          load(items)
         end
 
         def get(identity)

--- a/lib/fog/compute/google/models/global_addresses.rb
+++ b/lib/fog/compute/google/models/global_addresses.rb
@@ -5,8 +5,17 @@ module Fog
         model Fog::Compute::Google::GlobalAddress
 
         def all(options = {})
-          data = service.list_global_addresses(**options).to_h[:items] || []
-          load(data)
+          items = []
+          next_page_token = nil
+          loop do
+            data = service.list_global_addresses(**options)
+            next_items = data.to_h[:items] || []
+            items.concat(next_items)
+            next_page_token = data.next_page_token
+            break if next_page_token.nil? || next_page_token.empty?
+            options[:page_token] = next_page_token
+          end
+          load(items)
         end
 
         def get(identity)

--- a/lib/fog/compute/google/models/global_forwarding_rules.rb
+++ b/lib/fog/compute/google/models/global_forwarding_rules.rb
@@ -5,8 +5,17 @@ module Fog
         model Fog::Compute::Google::GlobalForwardingRule
 
         def all(opts = {})
-          data = service.list_global_forwarding_rules(**opts).to_h[:items] || []
-          load(data)
+          items = []
+          next_page_token = nil
+          loop do
+            data = service.list_global_forwarding_rules(**opts)
+            next_items = data.to_h[:items] || []
+            items.concat(next_items)
+            next_page_token = data.next_page_token
+            break if next_page_token.nil? || next_page_token.empty?
+            opts[:page_token] = next_page_token
+          end
+          load(items)
         end
 
         def get(identity)

--- a/lib/fog/compute/google/models/http_health_checks.rb
+++ b/lib/fog/compute/google/models/http_health_checks.rb
@@ -4,9 +4,18 @@ module Fog
       class HttpHealthChecks < Fog::Collection
         model Fog::Compute::Google::HttpHealthCheck
 
-        def all(_filters = {})
-          data = service.list_http_health_checks.to_h[:items] || []
-          load(data)
+        def all(opts = {})
+          items = []
+          next_page_token = nil
+          loop do
+            data = service.list_http_health_checks(**opts)
+            next_items = data.to_h[:items] || []
+            items.concat(next_items)
+            next_page_token = data.next_page_token
+            break if next_page_token.nil? || next_page_token.empty?
+            opts[:page_token] = next_page_token
+          end
+          load(items)
         end
 
         def get(identity)

--- a/lib/fog/compute/google/models/instance_templates.rb
+++ b/lib/fog/compute/google/models/instance_templates.rb
@@ -4,9 +4,18 @@ module Fog
       class InstanceTemplates < Fog::Collection
         model Fog::Compute::Google::InstanceTemplate
 
-        def all
-          data = service.list_instance_templates.items || []
-          load(data.map(&:to_h))
+        def all(opts = {})
+          items = []
+          next_page_token = nil
+          loop do
+            data = service.list_instance_templates(**opts)
+            next_items = data.items || []
+            items.concat(next_items)
+            next_page_token = data.next_page_token
+            break if next_page_token.nil? || next_page_token.empty?
+            opts[:page_token] = next_page_token
+          end
+          load(items.map(&:to_h))
         end
 
         def get(identity)

--- a/lib/fog/compute/google/models/machine_types.rb
+++ b/lib/fog/compute/google/models/machine_types.rb
@@ -11,16 +11,25 @@ module Fog
             :order_by => order_by,
             :page_token => page_token
           }
-
-          if zone
-            data = service.list_machine_types(zone, **opts).items
-          else
-            data = []
-            service.list_aggregated_machine_types(**opts).items.each_value do |scoped_list|
-              data.concat(scoped_list.machine_types) if scoped_list && scoped_list.machine_types
+          items = []
+          next_page_token = nil
+          loop do
+            if zone
+              data = service.list_machine_types(zone, **opts)
+              next_items = data.items || []
+              items.concat(next_items)
+              next_page_token = data.next_page_token
+            else
+              data = service.list_aggregated_machine_types(**opts)
+              data.items.each_value do |scoped_list|
+                items.concat(scoped_list.machine_types) if scoped_list && scoped_list.machine_types
+              end
+              next_page_token = data.next_page_token
             end
+            break if next_page_token.nil? || next_page_token.empty?
+            opts[:page_token] = next_page_token
           end
-          load(data.map(&:to_h) || [])
+          load(items.map(&:to_h) || [])
         end
 
         def get(identity, zone = nil)

--- a/lib/fog/compute/google/models/networks.rb
+++ b/lib/fog/compute/google/models/networks.rb
@@ -4,9 +4,18 @@ module Fog
       class Networks < Fog::Collection
         model Fog::Compute::Google::Network
 
-        def all
-          data = service.list_networks.to_h[:items]
-          load(data || [])
+        def all(opts = {})
+          items = []
+          next_page_token = nil
+          loop do
+            data = service.list_networks(**opts)
+            next_items = data.to_h[:items] || []
+            items.concat(next_items)
+            next_page_token = data.next_page_token
+            break if next_page_token.nil? || next_page_token.empty?
+            opts[:page_token] = next_page_token
+          end
+          load(items)
         end
 
         def get(identity)

--- a/lib/fog/compute/google/models/regions.rb
+++ b/lib/fog/compute/google/models/regions.rb
@@ -4,9 +4,18 @@ module Fog
       class Regions < Fog::Collection
         model Fog::Compute::Google::Region
 
-        def all
-          data = service.list_regions.to_h
-          load(data[:items] || [])
+        def all(opts = {})
+          items = []
+          next_page_token = nil
+          loop do
+            data = service.list_regions(**opts)
+            next_items = data.to_h[:items] || []
+            items.concat(next_items)
+            next_page_token = data.next_page_token
+            break if next_page_token.nil? || next_page_token.empty?
+            opts[:page_token] = next_page_token
+          end
+          load(items)
         end
 
         def get(identity)

--- a/lib/fog/compute/google/models/routes.rb
+++ b/lib/fog/compute/google/models/routes.rb
@@ -4,9 +4,18 @@ module Fog
       class Routes < Fog::Collection
         model Fog::Compute::Google::Route
 
-        def all
-          data = service.list_routes.to_h
-          load(data[:items] || [])
+        def all(opts = {})
+          items = []
+          next_page_token = nil
+          loop do
+            data = service.list_routes(**opts)
+            next_items = data.to_h[:items] || []
+            items.concat(next_items)
+            next_page_token = data.next_page_token
+            break if next_page_token.nil? || next_page_token.empty?
+            opts[:page_token] = next_page_token
+          end
+          load(items)
         end
 
         def get(identity)

--- a/lib/fog/compute/google/models/ssl_certificates.rb
+++ b/lib/fog/compute/google/models/ssl_certificates.rb
@@ -14,9 +14,18 @@ module Fog
           nil
         end
 
-        def all(_filters = {})
-          data = service.list_ssl_certificates.to_h[:items] || []
-          load(data)
+        def all(opts = {})
+          items = []
+          next_page_token = nil
+          loop do
+            data = service.list_ssl_certificates(**opts)
+            next_items = data.to_h[:items] || []
+            items.concat(next_items)
+            next_page_token = data.next_page_token
+            break if next_page_token.nil? || next_page_token.empty?
+            opts[:page_token] = next_page_token
+          end
+          load(items)
         end
       end
     end

--- a/lib/fog/compute/google/models/target_http_proxies.rb
+++ b/lib/fog/compute/google/models/target_http_proxies.rb
@@ -4,9 +4,18 @@ module Fog
       class TargetHttpProxies < Fog::Collection
         model Fog::Compute::Google::TargetHttpProxy
 
-        def all(_filters = {})
-          data = service.list_target_http_proxies.to_h[:items] || []
-          load(data)
+        def all(opts = {})
+          items = []
+          next_page_token = nil
+          loop do
+            data = service.list_target_http_proxies(*opts)
+            next_items = data.to_h[:items] || []
+            items.concat(next_items)
+            next_page_token = data.next_page_token
+            break if next_page_token.nil? || next_page_token.empty?
+            opts[:page_token] = next_page_token
+          end
+          load(items)
         end
 
         def get(identity)

--- a/lib/fog/compute/google/models/target_https_proxies.rb
+++ b/lib/fog/compute/google/models/target_https_proxies.rb
@@ -4,9 +4,18 @@ module Fog
       class TargetHttpsProxies < Fog::Collection
         model Fog::Compute::Google::TargetHttpsProxy
 
-        def all(_filters = {})
-          data = service.list_target_https_proxies.to_h[:items] || []
-          load(data)
+        def all(opts = {})
+          items = []
+          next_page_token = nil
+          loop do
+            data = service.list_target_https_proxies(**opts)
+            next_items = data.to_h[:items] || []
+            items.concat(next_items)
+            next_page_token = data.next_page_token
+            break if next_page_token.nil? || next_page_token.empty?
+            opts[:page_token] = next_page_token
+          end
+          load(items)
         end
 
         def get(identity)

--- a/lib/fog/compute/google/models/url_maps.rb
+++ b/lib/fog/compute/google/models/url_maps.rb
@@ -4,9 +4,18 @@ module Fog
       class UrlMaps < Fog::Collection
         model Fog::Compute::Google::UrlMap
 
-        def all
-          data = service.list_url_maps.to_h[:items] || []
-          load(data)
+        def all(opts = {})
+          items = []
+          next_page_token = nil
+          loop do
+            data = service.list_url_maps(**opts)
+            next_items = data.to_h[:items] || []
+            items.concat(next_items)
+            next_page_token = data.next_page_token
+            break if next_page_token.nil? || next_page_token.empty?
+            opts[:page_token] = next_page_token
+          end
+          load(items)
         end
 
         def get(identity)

--- a/lib/fog/compute/google/models/zones.rb
+++ b/lib/fog/compute/google/models/zones.rb
@@ -4,9 +4,18 @@ module Fog
       class Zones < Fog::Collection
         model Fog::Compute::Google::Zone
 
-        def all
-          data = service.list_zones.to_h[:items] || []
-          load(data)
+        def all(opts = {})
+          items = []
+          next_page_token = nil
+          loop do
+            data = service.list_zones
+            next_items = data.to_h[:items] || []
+            items.concat(next_items)
+            next_page_token = data.next_page_token
+            break if next_page_token.nil? || next_page_token.empty?
+            opts[:page_token] = next_page_token
+          end
+          load(items)
         end
 
         def get(identity)


### PR DESCRIPTION
Most of the models' `#all` methods are missing paging which limits the number of results to a maximum of 500.